### PR TITLE
to_port optional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     from_ip: "{{ item.from_ip | default('any') }}"
     to_ip: "{{ item.to_ip | default('any') }}"
     from_port: "{{ item.from_port | default('') }}"
-    to_port: "{{ item.to_port }}"
+    to_port: "{{ item.to_port | default('') }}"
     protocol: "{{ item.protocol | default('any') }}"
     log: "{{ item.log | default(False) }}"
   with_items: uwf_rules


### PR DESCRIPTION
Hi,

Just started using your role. Pretty much the best I found out there. Great work thanks :+1: 

I want disable to_port to be mandatory to allow traffic for all port from a specific network or IP i.e. VPN.

let me know what you think 
Thanks
