### PR TITLE
support multiline `ansible_managed` text

### DIFF
--- a/templates/etc/default/ufw.j2
+++ b/templates/etc/default/ufw.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment(prefix='', postfix='') }}
 
 # /etc/default/ufw
 #


### PR DESCRIPTION
If the `ansible_managed` text is customised in `ansible.cfg` to contain multiple lines, the subsequent lines weren't commented, leading to a validation failure of the ufw config. E.g. for the following `ansible.cfg`:
```
[defaults]
ansible_managed = This file is managed by Ansible.
  Your manual changes will be lost!
```
the comment would be rendered as
```
# This file is managed by Ansible.
Your manual changes will be lost!
```
and the validation fails.

https://docs.ansible.com/ansible/2.9/user_guide/playbooks_filters.html#comment-filter
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/comment_filter.html

The explicitly empty prefix and suffix aren't necessary and could be removed to simplify. However, I'm setting them explicitly to prevent unnecessary file changes after users upgrade the role, since by default, the `comment` filter inserts an empty comment line as prefix and suffix, e.g.,
```
#
# This file is managed by Ansible.
#
```
which is different from the previous behaviour.