### PR TITLE
fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 ---
 - name: facts | set
   ansible.builtin.set_fact:
-    kernel_version: "{{ ansible_kernel | regex_search('^([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
+    kernel_version: "{{ ansible_facts['kernel'] | regex_search('^([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
   tags:
     - configuration
     - ufw


### PR DESCRIPTION
Hi,

this fixes:

```bash
TASK [oefenweb.ufw : facts | set] *********************************************************************************************************************************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core ver
sion 2.24.
Origin: /home/ansible-dev/ansible-homeserver/roles/oefenweb.ufw/tasks/main.yml:5:21

3 - name: facts | set
4   ansible.builtin.set_fact:
5     kernel_version: "{{ ansible_kernel | regex_search('^([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
                      ^ column 21

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```